### PR TITLE
fix: Correct dependencies to resolve build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "@google/genai": "^1.13.0",
+    "@google/generative-ai": "^0.11.3",
     "@vercel/blob": "^0.23.2",
     "firebase-admin": "^12.1.0",
     "googleapis": "^137.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@vercel/node": "^3.1.5",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
   }


### PR DESCRIPTION
This commit resolves Vercel build errors caused by incorrect or missing package dependencies in `package.json`.

1.  **Updates `@google/genai` to `@google/generative-ai`**: The official package name for the Google AI SDK was updated, and this change aligns the project with the correct name, fixing a "module not found" error.
2.  **Adds `@vercel/node` to `devDependencies`**: The serverless functions in the `api/` directory use types like `VercelRequest` and `VercelResponse`. This change adds the necessary type definitions, resolving the "Cannot find module" errors during the TypeScript build process.