### PR TITLE
feat: Add daily data aggregation service

### DIFF
--- a/api/aggregation/trigger.ts
+++ b/api/aggregation/trigger.ts
@@ -1,0 +1,52 @@
+import { runDailyAggregation } from '../../services/jobs/aggregator';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+function isAuthorized(request: VercelRequest): boolean {
+  const sharedSecret = process.env.ADMIN_SHARED_SECRET;
+  const requestSecret = request.headers['x-admin-secret'];
+
+  if (!sharedSecret) {
+    console.warn("ADMIN_SHARED_SECRET is not configured. Denying all requests for this endpoint.");
+    return false;
+  }
+  return sharedSecret === requestSecret;
+}
+
+export default async function handler(
+  request: VercelRequest,
+  response: VercelResponse,
+) {
+  if (request.method !== 'POST') {
+    return response.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  if (!isAuthorized(request)) {
+    return response.status(403).json({ message: 'Forbidden: Admin access required.' });
+  }
+
+  const { date } = request.body; // Optional date parameter
+
+  // Validate date format if provided
+  if (date && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return response.status(400).json({
+      message: 'Invalid date format. Please use YYYY-MM-DD or omit to process yesterday.',
+    });
+  }
+
+  try {
+    // Run the job in the background
+    runDailyAggregation(date).catch(error => {
+        console.error(`[Background Aggregation Job] Error for date ${date || 'yesterday'}:`, error);
+    });
+
+    const jobDate = date || 'yesterday';
+    return response.status(202).json({
+      message: 'Aggregation job accepted and is running in the background.',
+      details: `Processing data for ${jobDate}.`,
+    });
+
+  } catch (error: any) {
+    console.error('Failed to start aggregation job:', error);
+    return response.status(500).json({ message: 'Failed to start aggregation job.', error: error.message });
+  }
+}

--- a/docs/schemas/analytics_agg_schema.md
+++ b/docs/schemas/analytics_agg_schema.md
@@ -1,0 +1,65 @@
+# Analytics Aggregates Schema
+
+This document outlines the JSON schema for the documents stored in the daily analytics collections located at `analytics_agg/daily_{YYYYMMDD}/results`.
+
+The job produces two types of documents: `site_summary` and `page_summary`.
+
+---
+
+## 1. Site Summary (`site_summary`)
+
+This document type provides a daily summary of performance metrics for a specific combination of `site`, `country`, and `device`.
+
+**Document ID:** `site_{siteUrl}_{country}_{device}`
+
+### Fields
+
+| Field Name | Type | Description | Example |
+|---|---|---|---|
+| `type` | String | The type of the document. Always `"site_summary"`. | `"site_summary"` |
+| `siteUrl` | String | The domain of the site being analyzed. | `"sc-domain:your-site.com"` |
+| `country` | String | The three-letter country code (ISO 3166-1 alpha-3). | `"USA"` |
+| `device` | String | The device category. | `"DESKTOP"` |
+| `clicks` | Number | The total number of clicks for this combination. | `1520` |
+| `impressions` | Number | The total number of impressions for this combination. | `45800` |
+
+### Example JSON
+
+```json
+{
+  "type": "site_summary",
+  "siteUrl": "sc-domain:your-site.com",
+  "country": "USA",
+  "device": "DESKTOP",
+  "clicks": 1520,
+  "impressions": 45800
+}
+```
+
+---
+
+## 2. Page Summary (`page_summary`)
+
+This document type provides a daily summary of performance metrics for a specific canonical URL.
+
+**Document ID:** `page_{base64_hash_of_url}`
+
+### Fields
+
+| Field Name | Type | Description | Example |
+|---|---|---|---|
+| `type` | String | The type of the document. Always `"page_summary"`. | `"page_summary"` |
+| `url` | String | The canonical URL of the page. | `"https://your-site.com/blog/my-post"` |
+| `clicks` | Number | The total number of clicks for this page. | `85` |
+| `impressions` | Number | The total number of impressions for this page. | `1250` |
+
+### Example JSON
+
+```json
+{
+  "type": "page_summary",
+  "url": "https://your-site.com/blog/my-post",
+  "clicks": 85,
+  "impressions": 1250
+}
+```

--- a/services/jobs/aggregator.ts
+++ b/services/jobs/aggregator.ts
@@ -1,0 +1,102 @@
+import { firestore } from '../firebase';
+import type { GscRawData } from '../../types';
+
+const GSC_RAW_COLLECTION = 'gsc_raw';
+const ANALYTICS_AGG_COLLECTION = 'analytics_agg';
+
+interface AggregatedMetrics {
+  clicks: number;
+  impressions: number;
+  // Position is not suitable for simple aggregation, so we omit it.
+  // A more complex calculation would be needed, like weighted average.
+}
+
+/**
+ * Calculates the date string for the previous day in YYYY-MM-DD format.
+ */
+function getYesterdayDateString(): string {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  return yesterday.toISOString().split('T')[0];
+}
+
+/**
+ * Runs the daily aggregation job.
+ * - Reads all raw GSC data for the previous day.
+ * - Aggregates metrics by site|country|device and by page.
+ * - Writes the aggregated results to a new daily collection in Firestore.
+ * @param date The date to process in YYYY-MM-DD format. Defaults to yesterday.
+ */
+export async function runDailyAggregation(date: string = getYesterdayDateString()) {
+  console.log(`Starting daily aggregation for date: ${date}`);
+
+  const snapshot = await firestore.collection(GSC_RAW_COLLECTION)
+    .where('date', '==', date)
+    .get();
+
+  if (snapshot.empty) {
+    console.log(`No raw data found for ${date}. Aggregation skipped.`);
+    return;
+  }
+
+  const siteAggregates = new Map<string, AggregatedMetrics>();
+  const pageAggregates = new Map<string, AggregatedMetrics>();
+
+  console.log(`Processing ${snapshot.size} raw documents...`);
+
+  snapshot.forEach(doc => {
+    const data = doc.data() as GscRawData;
+    const { siteUrl, country, device, url: pageUrl, clicks = 0, impressions = 0 } = data;
+
+    if (!siteUrl || !country || !device || !pageUrl) {
+      return; // Skip records with missing key dimensions
+    }
+
+    // R4: Produce daily aggregated metrics for site|country|device
+    const siteAggKey = `${siteUrl}|${country}|${device}`;
+    const currentSiteAgg = siteAggregates.get(siteAggKey) || { clicks: 0, impressions: 0 };
+    currentSiteAgg.clicks += clicks;
+    currentSiteAgg.impressions += impressions;
+    siteAggregates.set(siteAggKey, currentSiteAgg);
+
+    // R5: Produce page-level aggregates for each canonical URL
+    // As per plan, we assume the normalized URL from ingestion is the canonical URL.
+    const currentPageAgg = pageAggregates.get(pageUrl) || { clicks: 0, impressions: 0 };
+    currentPageAgg.clicks += clicks;
+    currentPageAgg.impressions += impressions;
+    pageAggregates.set(pageUrl, currentPageAgg);
+  });
+
+  // R6: Write the aggregated data to a new daily subcollection
+  const dailyCollectionId = `daily_${date.replace(/-/g, '')}`;
+  const dailyAggCollection = firestore.collection(ANALYTICS_AGG_COLLECTION).doc(dailyCollectionId).collection('results');
+
+  const batch = firestore.batch();
+  let batchCounter = 0;
+
+  console.log('Writing site-level aggregates...');
+  for (const [key, metrics] of siteAggregates.entries()) {
+    const [siteUrl, country, device] = key.split('|');
+    const docRef = dailyAggCollection.doc(`site_${siteUrl}_${country}_${device}`);
+    batch.set(docRef, { type: 'site_summary', siteUrl, country, device, ...metrics });
+    batchCounter++;
+  }
+
+  console.log('Writing page-level aggregates...');
+  for (const [pageUrl, metrics] of pageAggregates.entries()) {
+    // Using a hash of the URL for a cleaner document ID
+    const docId = `page_${Buffer.from(pageUrl).toString('base64')}`;
+    const docRef = dailyAggCollection.doc(docId);
+    batch.set(docRef, { type: 'page_summary', url: pageUrl, ...metrics });
+    batchCounter++;
+  }
+
+  if (batchCounter > 0) {
+    await batch.commit();
+    console.log(`Successfully wrote ${batchCounter} aggregated documents to '${ANALYTICS_AGG_COLLECTION}/${dailyCollectionId}/results'.`);
+  } else {
+    console.log('No aggregated documents to write.');
+  }
+
+  console.log(`Daily aggregation for ${date} complete.`);
+}


### PR DESCRIPTION
This commit introduces a new backend service to perform daily normalization and aggregation of raw Google Search Console data.

Key Features:
- **Aggregation Service (`services/jobs/aggregator.ts`)**:
  - A new service that runs a daily job to process the previous day's data from the `gsc_raw` Firestore collection.
  - Performs canonical resolution (assuming normalized URL is canonical).
  - Produces daily aggregated metrics for two dimensions:
    1. Site-level aggregates (by country and device).
    2. Page-level aggregates.
  - Writes the results to a new daily subcollection: `analytics_agg/daily_{YYYYMMDD}`.

- **Manual Trigger API (`/api/aggregation/trigger`)**:
  - A new protected API endpoint to manually trigger the aggregation job for a specific date, which is useful for testing and backfilling data.

- **Documentation**:
  - Includes a new markdown file (`docs/schemas/analytics_agg_schema.md`) that documents the JSON schema of the aggregated data written to Firestore.