### PR TITLE
fix: Correct GscRawData type definition

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -63,11 +63,16 @@ export interface Task {
 }
 
 export interface GscRawData {
+    siteUrl: string;
+    date: string;
     query: string;
+    url: string;
+    country: string;
+    device: string;
     impressions: number;
-    url?: string;
-    clicks?: number;
-    ctr?: number;
+    clicks: number;
+    ctr: number;
+    position: number;
     searchAppearance?: 'web_stories' | 'web' | 'discover' | 'google_news_showcase';
 }
 


### PR DESCRIPTION
This commit resolves a series of TypeScript build errors in `services/jobs/aggregator.ts`.

The errors were caused by an incomplete type definition for `GscRawData` in `types.ts`. The type was missing several properties that are fetched and stored by the GSC ingestion service (`gsc-connector.ts`).

This change updates the `GscRawData` interface to include all the correct properties (`siteUrl`, `date`, `country`, `device`, `position`, etc.) and makes them non-optional, as they are always provided by the connector.

This ensures the type definition accurately reflects the data model, resolving the type-checking errors during the build.