### PR TITLE
fix: Correct import paths in API serverless functions

### DIFF
--- a/api/aggregation/trigger.ts
+++ b/api/aggregation/trigger.ts
@@ -1,4 +1,4 @@
-import { runDailyAggregation } from '../../services/jobs/aggregator';
+import { runDailyAggregation } from '../services/jobs/aggregator';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 function isAuthorized(request: VercelRequest): boolean {

--- a/api/diagnosis/trigger.ts
+++ b/api/diagnosis/trigger.ts
@@ -1,4 +1,4 @@
-import { runTrafficDeclineDiagnosis } from '../../services/jobs/traffic-analyzer';
+import { runTrafficDeclineDiagnosis } from '../services/jobs/traffic-analyzer';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 // This is a simplified authorization check. In a real-world app,

--- a/api/ingestion/trigger.ts
+++ b/api/ingestion/trigger.ts
@@ -1,4 +1,4 @@
-import { fetchAndStoreGscData } from '../../services/ingestion/gsc-connector';
+import { fetchAndStoreGscData } from '../services/ingestion/gsc-connector';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 // TODO: Implement proper admin role-based authentication.

--- a/api/jobs/start-processing.ts
+++ b/api/jobs/start-processing.ts
@@ -1,4 +1,4 @@
-import { runInitialParse } from '../../services/jobs/parser';
+import { runInitialParse } from '../services/jobs/parser';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 function isAuthorized(request: VercelRequest): boolean {

--- a/api/upload.ts
+++ b/api/upload.ts
@@ -1,8 +1,8 @@
 import { put } from '@vercel/blob';
-import { firestore } from '../../services/firebase';
+import { firestore } from '../services/firebase';
 import { nanoid } from 'nanoid'; // A small library for generating unique IDs
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import type { ImportJob } from '../../types';
+import type { ImportJob } from '../types';
 
 const JOBS_COLLECTION = 'importJobs';
 


### PR DESCRIPTION
This commit resolves a series of TypeScript build errors (TS2307: Cannot find module) that were occurring in the Vercel serverless functions located in the `api/` directory.

The errors were caused by incorrect relative import paths. The paths were using `../../` which was one level too high. This change corrects all affected imports to use the proper `../` path to locate modules in the `services/` directory and the root `types.ts` file.