### PR TITLE
fix: Correct relative import paths in API routes

### DIFF
--- a/api/aggregation/trigger.ts
+++ b/api/aggregation/trigger.ts
@@ -1,4 +1,4 @@
-import { runDailyAggregation } from '../services/jobs/aggregator';
+import { runDailyAggregation } from '../../services/jobs/aggregator';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 function isAuthorized(request: VercelRequest): boolean {

--- a/api/diagnosis/trigger.ts
+++ b/api/diagnosis/trigger.ts
@@ -1,4 +1,4 @@
-import { runTrafficDeclineDiagnosis } from '../services/jobs/traffic-analyzer';
+import { runTrafficDeclineDiagnosis } from '../../services/jobs/traffic-analyzer';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 // This is a simplified authorization check. In a real-world app,

--- a/api/ingestion/trigger.ts
+++ b/api/ingestion/trigger.ts
@@ -1,4 +1,4 @@
-import { fetchAndStoreGscData } from '../services/ingestion/gsc-connector';
+import { fetchAndStoreGscData } from '../../services/ingestion/gsc-connector';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 // TODO: Implement proper admin role-based authentication.

--- a/api/jobs/start-processing.ts
+++ b/api/jobs/start-processing.ts
@@ -1,4 +1,4 @@
-import { runInitialParse } from '../services/jobs/parser';
+import { runInitialParse } from '../../services/jobs/parser';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 function isAuthorized(request: VercelRequest): boolean {


### PR DESCRIPTION
This commit resolves the "Cannot find module" (TS2307) build errors by correcting the relative import paths in all Vercel serverless functions.

The previous fix was incomplete. This change ensures that each API route in a subdirectory (e.g., `api/ingestion/trigger.ts`) uses the correct `../../` path to access modules from the root `services/` directory, while routes at the top level of `api/` (e.g., `api/upload.ts`) use the correct `../` path.

This ensures all local modules are resolved correctly during the build process.