### PR TITLE
fix: Correctly handle raw file uploads to prevent 500 error

### DIFF
--- a/api/upload.ts
+++ b/api/upload.ts
@@ -1,10 +1,17 @@
 import { put } from '@vercel/blob';
 import { firestore } from '../services/firebase';
-import { nanoid } from 'nanoid'; // A small library for generating unique IDs
+import { nanoid } from 'nanoid';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { ImportJob } from '../types';
+import { buffer } from '../utils/api-helpers';
 
 const JOBS_COLLECTION = 'importJobs';
+
+export const config = {
+  api: {
+    bodyParser: false, // We need to disable the default body parser to handle the raw stream
+  },
+};
 
 export default async function handler(
   request: VercelRequest,
@@ -14,21 +21,18 @@ export default async function handler(
     return response.status(405).json({ message: 'Method Not Allowed' });
   }
 
-  // We get the filename from a header instead of a query param now.
-  // This is a common pattern for file uploads.
   const filename = request.headers['x-vercel-filename'] as string || 'unknown-file';
-
-  if (!request.body) {
-    return response.status(400).json({ message: 'No file content provided.' });
-  }
-
   const jobId = nanoid();
   const blobPath = `uploads/${jobId}/${filename}`;
 
   try {
-    // 1. Upload the file to Vercel Blob storage
-    const blob = await put(blobPath, request.body, {
-      access: 'public', // The file needs to be public for the backend parser to fetch it
+    // 1. Buffer the raw request body into a single Buffer
+    const fileBuffer = await buffer(request);
+
+    // 2. Upload the buffered file to Vercel Blob storage
+    const blob = await put(blobPath, fileBuffer, {
+      access: 'public',
+      contentType: request.headers['content-type'], // Pass content type for correct handling
     });
 
     // 2. Create the initial job document in Firestore

--- a/utils/api-helpers.ts
+++ b/utils/api-helpers.ts
@@ -1,0 +1,22 @@
+import type { VercelRequest } from '@vercel/node';
+
+/**
+ * Reads the entire request body stream and returns it as a Buffer.
+ * This is necessary for handling raw file uploads in Vercel Serverless Functions.
+ * @param req The VercelRequest object.
+ * @returns A Promise that resolves with the complete request body as a Buffer.
+ */
+export function buffer(req: VercelRequest): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: any[] = [];
+    req.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks));
+    });
+    req.on('error', (err) => {
+      reject(err);
+    });
+  });
+}


### PR DESCRIPTION
This commit resolves a 500 Internal Server Error that occurred when uploading binary files (like XLSX).

The error was caused by the `/api/upload` serverless function not properly handling the incoming raw file stream. The fix involves two parts:
1.  A new helper utility (`utils/api-helpers.ts`) is created to buffer the entire request stream into a single Buffer object.
2.  The `/api/upload` endpoint is refactored to use this new helper. It now disables the default Vercel body parser and awaits the full file buffer before passing it to the Vercel Blob storage service.

This ensures that the file stream is handled correctly and reliably, preventing the server from crashing during uploads.