### PR TITLE
fix: Resolve final TypeScript build errors in services

### DIFF
--- a/services/jobs/parser.ts
+++ b/services/jobs/parser.ts
@@ -2,6 +2,7 @@ import { firestore } from '../firebase';
 import { head } from '@vercel/blob';
 import { put as vercelPut } from '@vercel/blob';
 import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
 import crypto from 'crypto';
 import type { ImportJob, ColumnMapping, GscRawData } from '../../types';
 import { normalizeUrl } from '../ingestion/url-normalizer';
@@ -188,8 +189,11 @@ function normalizeAndValidateRow(row: Record<string, any>, confirmedSchema: Colu
                     normalizedData.searchAppearance = val as GscRawData['searchAppearance'];
                 }
                 break;
-            default: // Handles query, siteUrl, country, device
-                normalizedData[mapping.targetField as keyof GscRawData] = String(rawValue).trim();
+            case 'query':
+            case 'siteUrl':
+            case 'country':
+            case 'device':
+                normalizedData[mapping.targetField] = String(rawValue).trim();
                 break;
         }
     });


### PR DESCRIPTION
This commit resolves the final set of TypeScript build errors that were occurring in the backend services.

1.  **Adds missing `firebase-admin` import**: The `traffic-analyzer.ts` service was using the `admin` namespace without importing the module. This has been corrected.
2.  **Adds Type Validation**: The `parser.ts` service was assigning a generic string to the `searchAppearance` property, which has a strict string literal type. Validation has been added to ensure only allowed values are assigned.
3.  **Restores `XLSX` import**: The `xlsx` library import was accidentally removed from `parser.ts` and has been restored.
4.  **Makes `switch` statement explicit**: The normalization logic in `parser.ts` was refactored to remove an ambiguous `default` case, making it fully type-safe.

These changes ensure the backend services are fully type-safe and resolve all outstanding build failures.