### PR TITLE
fix: Add .js extension to backend imports to resolve module errors

### DIFF
--- a/api/aggregation/trigger.ts
+++ b/api/aggregation/trigger.ts
@@ -1,4 +1,4 @@
-import { runDailyAggregation } from '../../services/jobs/aggregator';
+import { runDailyAggregation } from '../../services/jobs/aggregator.js';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 function isAuthorized(request: VercelRequest): boolean {

--- a/api/diagnosis/trigger.ts
+++ b/api/diagnosis/trigger.ts
@@ -1,4 +1,4 @@
-import { runTrafficDeclineDiagnosis } from '../../services/jobs/traffic-analyzer';
+import { runTrafficDeclineDiagnosis } from '../../services/jobs/traffic-analyzer.js';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 // This is a simplified authorization check. In a real-world app,

--- a/api/ingestion/trigger.ts
+++ b/api/ingestion/trigger.ts
@@ -1,4 +1,4 @@
-import { fetchAndStoreGscData } from '../../services/ingestion/gsc-connector';
+import { fetchAndStoreGscData } from '../../services/ingestion/gsc-connector.js';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 // TODO: Implement proper admin role-based authentication.


### PR DESCRIPTION
This commit resolves a recurring `ERR_MODULE_NOT_FOUND` error that was causing Vercel serverless function builds to fail.

The issue was that relative imports for local modules (e.g., from `/api` to `/services`) were missing the `.js` file extension. In an ES Modules context, particularly with Vercel's bundler, this extension is required for the runtime to correctly locate the compiled JavaScript files.

This change adds the `.js` extension to all relevant imports within the `/api` directory, ensuring that the module resolution works correctly during deployment.